### PR TITLE
Small improvements

### DIFF
--- a/taskjournal/taskjournal/cli/commands/daily.py
+++ b/taskjournal/taskjournal/cli/commands/daily.py
@@ -360,7 +360,8 @@ def build_app() -> Typer:
     @app.command(
         "sync",
         help=(
-            "Pull latest Jira tasks and add any missing ones to today's notes.\n\n"
+            "Pull latest Jira tasks (any status) assigned to you: add any missing "
+            "ones to today's notes and correct the status of any already tracked.\n\n"
             "Examples:\n"
             "  wk daily sync\n"
             "  wk daily sync --date 2026-06-25\n"

--- a/taskjournal/taskjournal/commands/daily.py
+++ b/taskjournal/taskjournal/commands/daily.py
@@ -305,9 +305,26 @@ class DailyCommands:
         previous_pending_tasks = self.task_manager.get_previous_pending_tasks(folder_path, current_file)
         recurring_descs = self._recurring.get_for_day(create_datetime)
         recurring_tasks = [TaskManager.create_task(d) for d in recurring_descs]
-        # Previous day's/week's carry-over tasks are appended after today's regular
-        # tasks so the daily notes lead with what's actually planned for today.
-        tasks = TaskManager.unique_tasks(default + pending + recurring_tasks + last_week_pending_tasks + previous_pending_tasks)
+
+        # Jira's "not done" query returns tickets regardless of when work on them
+        # started, so a still-TODO ticket already seen in yesterday's notes reads as
+        # carry-over, not new work — sink it below today's fresh/active tasks instead
+        # of letting it show up first.
+        carried_keys = {
+            key for t in previous_pending_tasks + last_week_pending_tasks if (key := getattr(t, "key", None))
+        }
+        fresh_pending = [
+            t for t in pending if getattr(t, "status", None) != Status.TODO or getattr(t, "key", None) not in carried_keys
+        ]
+        carried_pending = [
+            t for t in pending if getattr(t, "status", None) == Status.TODO and getattr(t, "key", None) in carried_keys
+        ]
+
+        # Recurring checklist items lead the list, followed by all Jira-sourced
+        # tasks (fresh/active ones first, then carry-over) — see comment above.
+        tasks = TaskManager.unique_tasks(
+            default + recurring_tasks + fresh_pending + carried_pending + last_week_pending_tasks + previous_pending_tasks
+        )
 
         all_tasks = tasks + code_review
         epic_names = TaskManager.get_unique_epic_names(all_tasks)
@@ -764,7 +781,7 @@ class DailyCommands:
             raise FileNotFoundError(f"No daily notes for {date.strftime('%Y-%m-%d')}")
 
         logger.debug("Fetching Jira tasks...")
-        pending = await self.jira.get_current_sprint_tasks_not_done_assigned_to_me()
+        assigned = await self.jira.get_current_sprint_tasks_all_assigned_to_me()
         code_review = await self.jira.get_current_sprint_tasks_in_code_review()
         async with self.github:
             await self.github.update_status_if_task_reviewed(code_review)
@@ -774,18 +791,23 @@ class DailyCommands:
         existing_descs = [t.description.lower() for t in existing_tasks]
 
         to_add = [
-            t for t in pending
+            t for t in assigned
             if not any(
                 (t.key and t.key in desc) or t.description.strip().lower() in desc
                 for desc in existing_descs
             )
         ]
 
+        lines = self.file_service.get_lines(file_path)
+        updated = self._correct_stale_task_statuses(lines, assigned + code_review)
+
         if not to_add:
-            console.print("[green]✓[/green] All Jira tasks already present in daily notes.")
+            if updated:
+                self.file_service.write_lines_to_file(file_path, lines)
+            else:
+                console.print("[green]✓[/green] All Jira tasks already present in daily notes.")
             return
 
-        lines = self.file_service.get_lines(file_path)
         task_rx = re_compile(r"^\s*-?\s*\[[ xX>~-]\]")
         in_planned = False
         last_task_idx = section_header_idx = -1

--- a/taskjournal/taskjournal/services/ai/base.py
+++ b/taskjournal/taskjournal/services/ai/base.py
@@ -56,12 +56,14 @@ def build_daily_prompt(note: ParsedNote) -> str:
 
     system = (
         "You are a senior software engineer writing a brief personal daily work journal entry. "
-        "Write 2 to 4 sentences in natural English, first person, past tense. "
-        "Do NOT use markdown headers, bullet points, or section titles. "
-        "Start directly with the journal entry. "
-        "Mention: what was accomplished, any blockers or unfinished work, "
-        "PR reviews if relevant, and firefighter incidents if present. "
-        "Work location is worth one brief mention if it is the office. "
+        "Structure the entry in two parts:\n"
+        "1. A short narrative summary, 3 to 8 lines, in natural English, first person, past tense. "
+        "No markdown headers or bullet points in this part — just prose. "
+        "Mention any blockers or unfinished work, and work location if it was the office.\n"
+        "2. A bullet list titled 'Highlights:' with one short line per notable thing done that day "
+        "(completed tasks, PR reviews, firefighter incidents), each on its own bullet so it reads "
+        "visually rather than as a paragraph.\n"
+        "Start directly with the narrative summary, no preamble. "
         "Keep the tone professional but natural — this is a personal journal, not a status report."
     )
 

--- a/taskjournal/taskjournal/services/parser.py
+++ b/taskjournal/taskjournal/services/parser.py
@@ -32,6 +32,12 @@ _STATUS_CHAR_MAP: dict[str, Status] = {
     "~": Status.CODE_REVIEW,
 }
 
+# Matches the leading "[KEY](link)" and "[🐙](github_link)" markdown that
+# TaskFormatter.format_task bakes into a rendered line, so re-parsed tasks
+# carry the same key as a freshly-fetched Jira task and dedupe correctly.
+_TASK_KEY_LINK_RE = compile(r"^\[([A-Z][A-Z0-9]*-\d+)\]\(([^)]*)\)")
+_TASK_GITHUB_RE = compile(r"^\[🐙\]\(([^)]*)\)")
+
 
 class ParserService(BaseService):
     def parse(self, file_path: str) -> ParsedNote | None:
@@ -142,8 +148,26 @@ class DailyParserService(ParserService):
 
         if task_match:
             status_char = task_match.group(1).lower()
-            description = task_match.group(2)
+            remainder = task_match.group(2)
             status = _STATUS_CHAR_MAP.get(status_char, Status.TODO)
-            task = Task(id=str(uuid4()), key=None, description=description, status=status)
+
+            key: str | None = None
+            link: str | None = None
+            github: str | None = None
+
+            key_match = _TASK_KEY_LINK_RE.match(remainder)
+            if key_match:
+                key = key_match.group(1)
+                link = key_match.group(2)
+                remainder = remainder[key_match.end():]
+
+            github_match = _TASK_GITHUB_RE.match(remainder)
+            if github_match:
+                github = github_match.group(1)
+                remainder = remainder[github_match.end():]
+
+            task = Task(
+                id=str(uuid4()), key=key, link=link, github=github, description=remainder, status=status
+            )
             section_list: list[Task] = getattr(note, current_section)
             section_list.append(task)

--- a/taskjournal/tests/commands/commands_test.py
+++ b/taskjournal/tests/commands/commands_test.py
@@ -1252,13 +1252,41 @@ class TestCommands:
         existing = Task(id="1", description="Fix bug", status=Status.TODO)
         cmd.parser.parse.return_value = ParsedNote(planned_tasks=[existing])
         pending = Task(id="1", description="Fix bug", status=Status.TODO)
-        cmd.jira.get_current_sprint_tasks_not_done_assigned_to_me = AsyncMock(return_value=[pending])
+        cmd.jira.get_current_sprint_tasks_all_assigned_to_me = AsyncMock(return_value=[pending])
         cmd.jira.get_current_sprint_tasks_in_code_review = AsyncMock(return_value=[])
         cmd.github.update_status_if_task_reviewed = AsyncMock()
 
         await cmd.sync_daily_notes(fixed_datetime)
 
         cmd.file_service.write_lines_to_file.assert_not_called()
+
+    @mark.asyncio
+    async def test_sync_daily_notes__corrects_status_of_task_moved_to_done(
+        self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
+    ) -> None:
+        # given: a task already tracked as in-progress in today's notes has
+        # since been moved to Done (or Rejected/any other status) in Jira.
+        mocker.patch.object(cmd._daily, "_get_daily_notes_file_path", return_value="/day.md")
+        mocker.patch("taskjournal.commands.daily.exists", return_value=True)
+        cmd.task_formatter.status_checkbox_char.side_effect = TaskFormatter.status_checkbox_char
+
+        lines = [
+            "## Planned Tasks\n",
+            " - [>] [JIRA-1]In progress task\n",
+        ]
+        cmd.file_service.get_lines.return_value = list(lines)
+        existing = Task(id="1", description="In progress task", status=Status.IN_PROGRESS)
+        cmd.parser.parse.return_value = ParsedNote(planned_tasks=[existing])
+
+        finished_task = Task(id="1", key="JIRA-1", description="In progress task", status=Status.DONE)
+        cmd.jira.get_current_sprint_tasks_all_assigned_to_me = AsyncMock(return_value=[finished_task])
+        cmd.jira.get_current_sprint_tasks_in_code_review = AsyncMock(return_value=[])
+        cmd.github.update_status_if_task_reviewed = AsyncMock()
+
+        await cmd.sync_daily_notes(fixed_datetime)
+
+        written_lines = cmd.file_service.write_lines_to_file.call_args[0][1]
+        assert any("JIRA-1" in line and "[x]" in line for line in written_lines)
 
     # ── sync_tasks ────────────────────────────────────────────────────────────
 

--- a/taskjournal/uv.lock
+++ b/taskjournal/uv.lock
@@ -1233,7 +1233,7 @@ wheels = [
 
 [[package]]
 name = "taskjournal"
-version = "0.67.0"
+version = "0.68.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# TaskJournal Pull Request Template

## Overview

1. wk daily sync ara també actualitza estats, no només afegeix tasques noves (commands/daily.py, cli/commands/daily.py)
  - Abans només consultava tasques "not done"; ara usa get_current_sprint_tasks_all_assigned_to_me (tots els estats) i corregeix l'estat de tasques ja trackejades a les notes (p. ex. si una tasca marcada com "in progress" ha passat a "Done" a Jira, es marca [x] al fitxer).
  - S'ha actualitzat el text d'ajuda del comando per reflectir aquest nou comportament.
2. Ordenació de tasques al daily (commands/daily.py)
  - Les tasques "carry-over" (ja vistes ahir/setmana passada i encara TODO) es mostren després de les tasques actives/noves d'avui, en lloc de barrejar-se amb elles, perquè la consulta "not done" de Jira no distingeix quan es va començar a treballar-hi.
3. Parsing de tasques preserva key/link/github (services/parser.py)
  - El parser ara reconeix el markdown [KEY](link) i [🐙](github_link) que genera el TaskFormatter, de manera que en re-parsejar una nota, la tasca conserva la seva key (necessari per fer el matching/dedupe amb Jira).
4. Prompt del resum diari d'IA reestructurat (services/ai/base.py)
  - Ara demana explícitament: (1) narrativa curta de 3-8 línies, i (2) llista de bullets "Highlights:" amb les coses destacades del dia (tasques completades, revisions de PR, incidents).
5. Tests nous/actualitzats per cobrir la correcció d'estat en sync (cas d'una tasca que passa a Done).
6. Bump de versió 0.67.0 → 0.68.0 a uv.lock.

## Checklist:

Go through these points to ensure the PR fulfills expectations.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
