### PR TITLE
small tweeks

### DIFF
--- a/taskjournal/taskjournal/cli/commands/daily.py
+++ b/taskjournal/taskjournal/cli/commands/daily.py
@@ -360,20 +360,31 @@ def build_app() -> Typer:
     @app.command(
         "sync",
         help=(
-            "Pull latest Jira tasks (any status) assigned to you: add any missing "
-            "ones to today's notes and correct the status of any already tracked.\n\n"
+            "Pull latest Jira tasks (any status) and code-review tasks assigned to "
+            "you: add whichever are missing to today's notes and correct the "
+            "status of any already tracked (e.g. a code-review approval).\n\n"
             "Examples:\n"
             "  wk daily sync\n"
             "  wk daily sync --date 2026-06-25\n"
+            "  wk daily sync --prs\n"
         ),
     )
     def daily_sync(
         ctx: Context,
         date: str | None = Option(None, "--date", help="Date: 'YYYY-MM-DD'."),
+        prs: bool = Option(
+            False, "--prs", help="Also add PRs pending your review as tasks."
+        ),
     ) -> None:
         today = parse_date(date) if date else get_today(ctx)
         try:
             run(get_manager(ctx).sync_daily_notes(today))
+            if prs:
+                added = run(get_manager(ctx).sync_prs(today))
+                if added == 0:
+                    console.print("[green]✓[/green] All PRs already in daily notes.")
+                else:
+                    console.print(f"[green]✓[/green] Added {added} PR(s) to daily notes.")
         except (FileNotFoundError, ValueError) as e:
             logger.error(str(e))
             sys_exit(1)
@@ -391,7 +402,11 @@ def build_app() -> Typer:
     def daily_audit(
         ctx: Context,
         year: int | None = Option(None, "--year", help="Year to scan (default: current year)."),
-        fix: bool = Option(False, "--fix", help="Open each incomplete file in $EDITOR."),
+        fix: bool = Option(
+            False,
+            "--fix",
+            help="Automatically fix incomplete files (AI summary, end time = start + 8h, computed time spent).",
+        ),
     ) -> None:
         today = get_today(ctx)
         target_year = year or today.year
@@ -437,7 +452,11 @@ def build_app() -> Typer:
             console.print()
             for date_str, file_path, issues in [(d, f, i) for d, f, i in results if i]:
                 console.print(f"[bold cyan]{date_str}[/bold cyan]  [yellow]{' · '.join(issues)}[/yellow]")
-                _fix_file_interactively(manager, date_str, file_path, issues)
+                fixed = run(manager.fix_note_automatically(date_str, file_path, issues))
+                if fixed:
+                    console.print(f"  [green]✓ Fixed: {', '.join(fixed)}[/green]")
+                else:
+                    console.print("  [dim]Nothing could be fixed automatically[/dim]")
                 console.print()
 
         console.print()

--- a/taskjournal/taskjournal/cli/commands/info.py
+++ b/taskjournal/taskjournal/cli/commands/info.py
@@ -163,10 +163,8 @@ def build_app() -> Typer:
         friday = monday + timedelta(days=4)
         table.add_row("Dates", f"{monday.strftime('%d %b')} – {friday.strftime('%d %b %Y')}")
 
-        weekday = today.weekday()
-        days_before_today = min(weekday, 5)
         accumulated_s = TimeService.get_accumulated_week_seconds(week_folder, today)
-        expected_s = days_before_today * 8 * 3600
+        expected_s = TimeService.get_expected_week_seconds_before(today)
         extra_s = accumulated_s - expected_s
         acc_h, acc_m = TimeService.seconds_to_hours_minutes(accumulated_s)
         exp_h, exp_m = TimeService.seconds_to_hours_minutes(expected_s)

--- a/taskjournal/taskjournal/cli/commands/task.py
+++ b/taskjournal/taskjournal/cli/commands/task.py
@@ -1,4 +1,3 @@
-from asyncio import run
 from sys import exit as sys_exit
 
 from rich.table import Table
@@ -110,28 +109,6 @@ def build_app() -> Typer:
             else:
                 logger.warning(f"No matching task found for: {description}")
         except FileNotFoundError as e:
-            logger.error(str(e))
-            sys_exit(1)
-
-    @app.command(
-        "sync",
-        help=(
-            "Check your active Jira task and code-review tasks against today's "
-            "notes: add whichever are missing, and correct the status of any "
-            "that have gone stale (e.g. a code-review approval).\n\n"
-            "Examples:\n"
-            "  wk task sync\n"
-            "  wk task sync --date 2026-06-25\n"
-        ),
-    )
-    def task_sync(
-        ctx: Context,
-        date: str | None = Option(None, "--date", help="Date: 'YYYY-MM-DD'."),
-    ) -> None:
-        today = parse_date(date) if date else get_today(ctx)
-        try:
-            run(get_manager(ctx).sync_tasks(today))
-        except (FileNotFoundError, ValueError) as e:
             logger.error(str(e))
             sys_exit(1)
 

--- a/taskjournal/taskjournal/commands/commands.py
+++ b/taskjournal/taskjournal/commands/commands.py
@@ -159,6 +159,9 @@ class CommandManager:
     def fix_summary(self, file_path: str, summary_text: str) -> None:
         return self._daily.fix_summary(file_path, summary_text)
 
+    async def fix_note_automatically(self, date_str: str, file_path: str, issues: list[str]) -> list[str]:
+        return await self._daily.fix_note_automatically(date_str, file_path, issues)
+
     def audit_daily_notes(self, year: int) -> list[tuple[str, str, list[str]]]:
         return self._daily.audit_daily_notes(year)
 
@@ -174,7 +177,7 @@ class CommandManager:
     def get_streak_stats(self, today: datetime) -> dict[str, object]:
         return self._daily.get_streak_stats(today)
 
-    async def sync_daily_notes(self, date: datetime) -> None:
+    async def sync_daily_notes(self, date: datetime) -> tuple[int, int]:
         return await self._daily.sync_daily_notes(date)
 
     def _get_week_folder(self, date: datetime) -> str:
@@ -222,9 +225,6 @@ class CommandManager:
 
     def wip_task_in_daily(self, date: datetime, description: str) -> bool:
         return self._tasks.wip_task_in_daily(date, description)
-
-    async def sync_tasks(self, date: datetime) -> tuple[int, int]:
-        return await self._daily.sync_task_statuses(date)
 
     # ── Reports ───────────────────────────────────────────────────────────────
 

--- a/taskjournal/taskjournal/commands/daily.py
+++ b/taskjournal/taskjournal/commands/daily.py
@@ -353,12 +353,12 @@ class DailyCommands:
 
         week_folder = self._get_week_folder(create_datetime)
         accumulated_seconds = self.time_service.get_accumulated_week_seconds(week_folder, create_datetime)
-        weekday = create_datetime.weekday()
-        days_before_today = min(weekday, 5)
-        expected_seconds = days_before_today * 8 * 3600
+        days_before_today = min(create_datetime.weekday(), 5)
+        expected_seconds = TimeService.get_expected_week_seconds_before(create_datetime)
         extra_seconds = accumulated_seconds - expected_seconds
-        today_work_seconds = min(8 * 3600, max(0, 8 * 3600 - extra_seconds))
-        finish = self.time_service.estimated_finish_time(create_datetime, accumulated_seconds, days_before_today)
+        today_seconds = TimeService.get_expected_workday_seconds(create_datetime)
+        today_work_seconds = min(today_seconds, max(0, today_seconds - extra_seconds))
+        finish = self.time_service.estimated_finish_time(create_datetime, accumulated_seconds)
 
         accumulated_h, accumulated_m = TimeService.seconds_to_hours_minutes(accumulated_seconds)
         expected_h, expected_m = TimeService.seconds_to_hours_minutes(expected_seconds)
@@ -590,7 +590,7 @@ class DailyCommands:
             return None
 
         try:
-            await self.sync_task_statuses(custom_date)
+            await self.sync_daily_notes(custom_date)
         except Exception as e:
             logger.warning(f"Code review sync failed: {e}")
 
@@ -736,6 +736,32 @@ class DailyCommands:
         self.file_service.write_lines_to_file(file_path, content)
         return True
 
+    async def fix_note_automatically(self, date_str: str, file_path: str, issues: list[str]) -> list[str]:
+        fixed: list[str] = []
+
+        if "missing end time" in issues:
+            lines = self.file_service.get_lines(file_path)
+            _, start_time = self.time_service.get_start_time(lines)
+            end_time = start_time + timedelta(seconds=TimeService.get_expected_workday_seconds(start_time))
+            self.fix_end_time_and_time_spent(file_path, end_time)
+            fixed += ["end time", "time spent"]
+        elif "missing time spent" in issues and self.fix_time_spent_from_file(file_path):
+            fixed.append("time spent")
+
+        if "missing summary" in issues:
+            note = self.parser.parse(file_path)
+            summary = None
+            if note is not None:
+                try:
+                    summary = await self.ai_service.summarize_day(note)
+                except Exception as e:
+                    logger.warning(f"AI summary failed for {date_str}: {e}")
+            if summary and not summary.startswith("⚠️"):
+                self.fix_summary(file_path, summary)
+                fixed.append("summary")
+
+        return fixed
+
     def fix_summary(self, file_path: str, summary_text: str) -> None:
         content = self.file_service.get_lines(file_path)
 
@@ -772,10 +798,13 @@ class DailyCommands:
         else:
             logger.error("Could not calculate working hours.")
 
-    async def sync_daily_notes(self, date: datetime) -> None:
-        from re import compile as re_compile
-        from taskjournal.services.parser import _SECTION_RULES
+    async def sync_daily_notes(self, date: datetime) -> tuple[int, int]:
+        """Reconcile today's notes with live Jira/GitHub state.
 
+        Adds any assigned Jira task (any status) or code-review task that's
+        missing, and corrects the checkbox of any task whose local status has
+        gone stale (e.g. a code-review approval, or a Jira status change).
+        """
         file_path = self._get_daily_notes_file_path(date)
         if not exists(file_path):
             raise FileNotFoundError(f"No daily notes for {date.strftime('%Y-%m-%d')}")
@@ -783,81 +812,15 @@ class DailyCommands:
         logger.debug("Fetching Jira tasks...")
         assigned = await self.jira.get_current_sprint_tasks_all_assigned_to_me()
         code_review = await self.jira.get_current_sprint_tasks_in_code_review()
-        async with self.github:
-            await self.github.update_status_if_task_reviewed(code_review)
-
-        existing_data = self.parser.parse(file_path)
-        existing_tasks = existing_data.planned_tasks if existing_data else []
-        existing_descs = [t.description.lower() for t in existing_tasks]
-
-        to_add = [
-            t for t in assigned
-            if not any(
-                (t.key and t.key in desc) or t.description.strip().lower() in desc
-                for desc in existing_descs
-            )
-        ]
-
-        lines = self.file_service.get_lines(file_path)
-        updated = self._correct_stale_task_statuses(lines, assigned + code_review)
-
-        if not to_add:
-            if updated:
-                self.file_service.write_lines_to_file(file_path, lines)
-            else:
-                console.print("[green]✓[/green] All Jira tasks already present in daily notes.")
-            return
-
-        task_rx = re_compile(r"^\s*-?\s*\[[ xX>~-]\]")
-        in_planned = False
-        last_task_idx = section_header_idx = -1
-
-        for i, raw in enumerate(lines):
-            stripped = raw.strip()
-            for sec_name, pat in _SECTION_RULES:
-                if pat.match(stripped):
-                    in_planned = sec_name == "planned_tasks"
-                    if in_planned:
-                        section_header_idx = i
-                    break
-            if in_planned and task_rx.match(stripped):
-                last_task_idx = i
-
-        insert_at = last_task_idx if last_task_idx != -1 else section_header_idx
-        if insert_at == -1:
-            raise ValueError("Planned Tasks section not found.")
-
-        for offset, task in enumerate(to_add):
-            formatted = self.task_formatter.format_task(task, with_name=True, with_status=False)
-            lines.insert(insert_at + 1 + offset, formatted + "\n")
-            console.print(f"  [green]+[/green] {task.description}")
-
-        self.file_service.write_lines_to_file(file_path, lines)
-
-    async def sync_task_statuses(self, date: datetime) -> tuple[int, int]:
-        """Reconcile today's notes with live Jira/GitHub state.
-
-        Adds the active Jira task if missing and re-checks code-review tasks,
-        correcting the checkbox of any task whose local status has gone stale
-        (e.g. a code-review approval, or a Jira status change) instead of only
-        adding tasks that are entirely missing.
-        """
-        file_path = self._get_daily_notes_file_path(date)
-        if not exists(file_path):
-            raise FileNotFoundError(f"No daily notes for {date.strftime('%Y-%m-%d')}")
-
-        logger.debug("Fetching Jira tasks...")
-        active = await self.jira.get_current_sprint_tasks_not_done_assigned_to_me()
-        code_review = await self.jira.get_current_sprint_tasks_in_code_review()
 
         lines = self.file_service.get_lines(file_path)
 
         async with self.github:
             await self.github.update_status_if_task_reviewed(code_review)
 
-            added = self._insert_missing_tasks_in_section(lines, "planned_tasks", active)
+            added = self._insert_missing_tasks_in_section(lines, "planned_tasks", assigned)
             added += self._insert_missing_tasks_in_section(lines, "code_review_tasks", code_review)
-            updated = self._correct_stale_task_statuses(lines, active + code_review)
+            updated = self._correct_stale_task_statuses(lines, assigned + code_review)
             # A ticket can leave Jira's "Code Review" status/sprint (e.g. moved
             # forward right after merging) before its PR is re-checked here, so
             # already-tracked code-review lines are re-verified directly against

--- a/taskjournal/taskjournal/constants.py
+++ b/taskjournal/taskjournal/constants.py
@@ -7,6 +7,11 @@ SECTION_FIREFIGHTER = "Firefighter"
 
 WORK_OFFICE_DAYS = ["Tuesday", "Thursday"]
 
+# Expected working hours per weekday — Mon-Thu run longer, Friday is shorter,
+# totalling the same 40h/week.
+WORKDAY_HOURS_MON_TO_THU = 8.5
+WORKDAY_HOURS_FRIDAY = 6.0
+
 # Work locations
 WORK_LOCATION_HOME = "Home"
 WORK_LOCATION_OFFICE = "Office"

--- a/taskjournal/taskjournal/services/backup.py
+++ b/taskjournal/taskjournal/services/backup.py
@@ -36,7 +36,7 @@ class BackupService(BaseService):
 
     @staticmethod
     def _get_backup_filename() -> str:
-        date_str = datetime.now().strftime("%Y_%m_%d")
+        date_str = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
         return f"DailyNotes_backup_{date_str}.zip"
 
     def create(self) -> Path:

--- a/taskjournal/taskjournal/services/file.py
+++ b/taskjournal/taskjournal/services/file.py
@@ -55,9 +55,8 @@ class FileService(BaseService):
 
     @staticmethod
     def get_week_folder(base_dir: str | Path, date_obj: datetime | date) -> str:
-        year = date_obj.year
-        week_num = date_obj.isocalendar()[1]
-        week_folder = join(str(base_dir), f"{year}", f"week{week_num}")
+        iso_year, week_num, _ = date_obj.isocalendar()
+        week_folder = join(str(base_dir), f"{iso_year}", f"week{week_num}")
         return week_folder
 
     @staticmethod

--- a/taskjournal/taskjournal/services/time.py
+++ b/taskjournal/taskjournal/services/time.py
@@ -3,6 +3,7 @@ from os import makedirs
 from os.path import exists, join
 
 from taskjournal.config import BASE_DIR, TEMPLATE_FORMAT
+from taskjournal.constants import WORKDAY_HOURS_FRIDAY, WORKDAY_HOURS_MON_TO_THU
 from taskjournal.services.base import BaseService
 from taskjournal.services.file import FileService
 from taskjournal.services.logger import logger
@@ -71,14 +72,28 @@ class TimeService(BaseService):
         return total
 
     @staticmethod
+    def get_expected_workday_seconds(day: datetime | date) -> int:
+        hours = WORKDAY_HOURS_FRIDAY if day.weekday() == 4 else WORKDAY_HOURS_MON_TO_THU
+        return int(hours * 3600)
+
+    @staticmethod
+    def get_expected_week_seconds_before(today: datetime) -> int:
+        start_of_week = today - timedelta(days=today.weekday())
+        days_before_today = min(today.weekday(), 5)  # Mon..Fri, capped for weekend notes
+        return sum(
+            TimeService.get_expected_workday_seconds(start_of_week + timedelta(days=i))
+            for i in range(days_before_today)
+        )
+
+    @staticmethod
     def estimated_finish_time(
         created_time: datetime,
         accumulated_seconds: int = 0,
-        days_before_today: int = 0,
     ) -> datetime:
-        expected_seconds = days_before_today * 8 * 3600
+        expected_seconds = TimeService.get_expected_week_seconds_before(created_time)
         extra_seconds = accumulated_seconds - expected_seconds
-        today_work_seconds = min(8 * 3600, max(0, 8 * 3600 - extra_seconds))
+        today_seconds = TimeService.get_expected_workday_seconds(created_time)
+        today_work_seconds = min(today_seconds, max(0, today_seconds - extra_seconds))
         lunch_seconds = 3600
         return created_time + timedelta(seconds=today_work_seconds + lunch_seconds)
 

--- a/taskjournal/tests/cli/daily_commands_test.py
+++ b/taskjournal/tests/cli/daily_commands_test.py
@@ -12,10 +12,10 @@ from typer.testing import Result
 from taskjournal.models.task import Status, Task
 
 
-class TestFixFileInteractively:
+class TestAuditAutoFix:
 
     @freeze_time("2026-01-19 10:00:00")
-    def test_fix_file_called_from_audit_when_user_says_yes(
+    def test_fix_calls_fix_note_automatically_for_each_incomplete_file(
         self,
         mocker: MockerFixture,
         cli_manager: MagicMock,
@@ -26,96 +26,37 @@ class TestFixFileInteractively:
         ]
         cli_manager.count_week_folders.return_value = 1
         cli_manager.audit_weekly_coverage.return_value = []
-
-        mocker.patch("builtins.input", side_effect=["A great day of work"])
+        cli_manager.fix_note_automatically = mocker.AsyncMock(return_value=["summary"])
 
         result = invoke_cli(["daily", "audit", "--fix"])
 
         assert result.exit_code == 0
-        cli_manager.fix_summary.assert_called_once_with("/day.md", "A great day of work")
+        cli_manager.fix_note_automatically.assert_called_once_with(
+            "2026-01-05", "/day.md", ["missing summary"]
+        )
+        assert "Fixed: summary" in result.stdout
 
     @freeze_time("2026-01-19 10:00:00")
-    def test_fix_file_missing_end_time_sets_it(
+    def test_fix_reports_when_nothing_could_be_fixed(
         self,
         mocker: MockerFixture,
         cli_manager: MagicMock,
         invoke_cli: Callable[[list[str]], Result],
     ) -> None:
         cli_manager.audit_daily_notes.return_value = [
-            ("2026-01-05", "/day.md", ["missing end time"]),
+            ("2026-01-05", "/day.md", ["missing start time"]),
         ]
         cli_manager.count_week_folders.return_value = 1
         cli_manager.audit_weekly_coverage.return_value = []
-
-        mocker.patch("builtins.input", side_effect=["17:30"])
+        cli_manager.fix_note_automatically = mocker.AsyncMock(return_value=[])
 
         result = invoke_cli(["daily", "audit", "--fix"])
 
         assert result.exit_code == 0
-        cli_manager.fix_end_time_and_time_spent.assert_called_once()
+        assert "Nothing could be fixed automatically" in result.stdout
 
     @freeze_time("2026-01-19 10:00:00")
-    def test_fix_file_invalid_end_time_format(
-        self,
-        mocker: MockerFixture,
-        cli_manager: MagicMock,
-        invoke_cli: Callable[[list[str]], Result],
-    ) -> None:
-        cli_manager.audit_daily_notes.return_value = [
-            ("2026-01-05", "/day.md", ["missing end time"]),
-        ]
-        cli_manager.count_week_folders.return_value = 1
-        cli_manager.audit_weekly_coverage.return_value = []
-
-        mocker.patch("builtins.input", side_effect=["not-valid"])
-
-        result = invoke_cli(["daily", "audit", "--fix"])
-
-        assert result.exit_code == 0
-        cli_manager.fix_end_time_and_time_spent.assert_not_called()
-
-    @freeze_time("2026-01-19 10:00:00")
-    def test_fix_file_missing_time_spent_fixes_from_file(
-        self,
-        mocker: MockerFixture,
-        cli_manager: MagicMock,
-        invoke_cli: Callable[[list[str]], Result],
-    ) -> None:
-        cli_manager.audit_daily_notes.return_value = [
-            ("2026-01-05", "/day.md", ["missing time spent"]),
-        ]
-        cli_manager.count_week_folders.return_value = 1
-        cli_manager.audit_weekly_coverage.return_value = []
-        cli_manager.fix_time_spent_from_file.return_value = True
-
-        result = invoke_cli(["daily", "audit", "--fix"])
-
-        assert result.exit_code == 0
-        cli_manager.fix_time_spent_from_file.assert_called_once_with("/day.md")
-
-    @freeze_time("2026-01-19 10:00:00")
-    def test_fix_file_missing_time_spent_asks_for_end_time_when_no_end(
-        self,
-        mocker: MockerFixture,
-        cli_manager: MagicMock,
-        invoke_cli: Callable[[list[str]], Result],
-    ) -> None:
-        cli_manager.audit_daily_notes.return_value = [
-            ("2026-01-05", "/day.md", ["missing time spent"]),
-        ]
-        cli_manager.count_week_folders.return_value = 1
-        cli_manager.audit_weekly_coverage.return_value = []
-        cli_manager.fix_time_spent_from_file.return_value = False
-
-        mocker.patch("builtins.input", side_effect=["17:45"])
-
-        result = invoke_cli(["daily", "audit", "--fix"])
-
-        assert result.exit_code == 0
-        cli_manager.fix_end_time_and_time_spent.assert_called_once()
-
-    @freeze_time("2026-01-19 10:00:00")
-    def test_fix_file_blank_summary_skips(
+    def test_fix_not_called_without_fix_flag(
         self,
         mocker: MockerFixture,
         cli_manager: MagicMock,
@@ -126,13 +67,12 @@ class TestFixFileInteractively:
         ]
         cli_manager.count_week_folders.return_value = 1
         cli_manager.audit_weekly_coverage.return_value = []
+        cli_manager.fix_note_automatically = mocker.AsyncMock(return_value=["summary"])
 
-        mocker.patch("builtins.input", side_effect=[""])
-
-        result = invoke_cli(["daily", "audit", "--fix"])
+        result = invoke_cli(["daily", "audit"])
 
         assert result.exit_code == 0
-        cli_manager.fix_summary.assert_not_called()
+        cli_manager.fix_note_automatically.assert_not_called()
 
 
 class TestDailyStatus:
@@ -255,6 +195,52 @@ class TestDailySync:
 
         assert result.exit_code == 1
         assert "no file" in caplog.text
+
+    @freeze_time("2026-01-19 10:00:00")
+    def test_daily_sync_without_prs_flag_does_not_sync_prs(
+        self,
+        cli_manager: MagicMock,
+        invoke_cli: Callable[[list[str]], Result],
+    ) -> None:
+        from unittest.mock import AsyncMock
+        cli_manager.sync_daily_notes = AsyncMock()
+        cli_manager.sync_prs = AsyncMock()
+
+        result = invoke_cli(["daily", "sync"])
+
+        assert result.exit_code == 0
+        cli_manager.sync_prs.assert_not_called()
+
+    @freeze_time("2026-01-19 10:00:00")
+    def test_daily_sync_with_prs_flag_also_syncs_prs(
+        self,
+        cli_manager: MagicMock,
+        invoke_cli: Callable[[list[str]], Result],
+    ) -> None:
+        from unittest.mock import AsyncMock
+        cli_manager.sync_daily_notes = AsyncMock()
+        cli_manager.sync_prs = AsyncMock(return_value=2)
+
+        result = invoke_cli(["daily", "sync", "--prs"])
+
+        assert result.exit_code == 0
+        cli_manager.sync_prs.assert_awaited_once_with(datetime(2026, 1, 19, 10, 0, 0))
+        assert "Added 2 PR(s)" in result.stdout
+
+    @freeze_time("2026-01-19 10:00:00")
+    def test_daily_sync_with_prs_flag_reports_when_none_added(
+        self,
+        cli_manager: MagicMock,
+        invoke_cli: Callable[[list[str]], Result],
+    ) -> None:
+        from unittest.mock import AsyncMock
+        cli_manager.sync_daily_notes = AsyncMock()
+        cli_manager.sync_prs = AsyncMock(return_value=0)
+
+        result = invoke_cli(["daily", "sync", "--prs"])
+
+        assert result.exit_code == 0
+        assert "All PRs already in daily notes" in result.stdout
 
 
 class TestDailyTask:

--- a/taskjournal/tests/commands/commands_test.py
+++ b/taskjournal/tests/commands/commands_test.py
@@ -895,6 +895,104 @@ class TestCommands:
         with pytest.raises(ValueError, match="Notes section not found"):
             cmd.add_note_to_daily(fixed_datetime, "note")
 
+    # ── fix_note_automatically ───────────────────────────────────────────────
+
+    @mark.asyncio
+    async def test_fix_note_automatically__fixes_missing_end_time_as_start_plus_expected_hours(
+        self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
+    ) -> None:
+        # fixed_datetime (2025-01-15) is a Wednesday → 8.5h expected workday
+        cmd.file_service.get_lines.return_value = ["**Start Time:** 09:00:00\n"]
+        cmd.time_service.get_start_time.return_value = (0, fixed_datetime.replace(hour=9, minute=0))
+        fix_end = mocker.patch.object(cmd._daily, "fix_end_time_and_time_spent")
+
+        fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing end time"])
+
+        fix_end.assert_called_once_with("/day.md", fixed_datetime.replace(hour=17, minute=30))
+        assert fixed == ["end time", "time spent"]
+
+    @mark.asyncio
+    async def test_fix_note_automatically__fixes_missing_end_time_as_start_plus_6h_on_friday(
+        self, cmd: CommandManager, mocker: MockerFixture
+    ) -> None:
+        friday = datetime(2025, 1, 17, 9, 0, 0)
+        cmd.file_service.get_lines.return_value = ["**Start Time:** 09:00:00\n"]
+        cmd.time_service.get_start_time.return_value = (0, friday)
+        fix_end = mocker.patch.object(cmd._daily, "fix_end_time_and_time_spent")
+
+        fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing end time"])
+
+        fix_end.assert_called_once_with("/day.md", friday.replace(hour=15, minute=0))
+        assert fixed == ["end time", "time spent"]
+
+    @mark.asyncio
+    async def test_fix_note_automatically__fixes_missing_time_spent_from_existing_end(
+        self, cmd: CommandManager, mocker: MockerFixture
+    ) -> None:
+        fix_spent = mocker.patch.object(cmd._daily, "fix_time_spent_from_file", return_value=True)
+
+        fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing time spent"])
+
+        fix_spent.assert_called_once_with("/day.md")
+        assert fixed == ["time spent"]
+
+    @mark.asyncio
+    async def test_fix_note_automatically__skips_time_spent_when_it_cannot_be_derived(
+        self, cmd: CommandManager, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(cmd._daily, "fix_time_spent_from_file", return_value=False)
+
+        fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing time spent"])
+
+        assert fixed == []
+
+    @mark.asyncio
+    async def test_fix_note_automatically__fixes_missing_summary_with_ai(
+        self, cmd: CommandManager, mocker: MockerFixture
+    ) -> None:
+        cmd.parser.parse.return_value = ParsedNote(summary=[])
+        cmd._daily.ai_service.summarize_day = AsyncMock(return_value="AI generated summary.")
+        fix_summary = mocker.patch.object(cmd._daily, "fix_summary")
+
+        fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing summary"])
+
+        fix_summary.assert_called_once_with("/day.md", "AI generated summary.")
+        assert fixed == ["summary"]
+
+    @mark.asyncio
+    async def test_fix_note_automatically__skips_summary_when_ai_fails(
+        self, cmd: CommandManager, mocker: MockerFixture
+    ) -> None:
+        cmd.parser.parse.return_value = ParsedNote(summary=[])
+        cmd._daily.ai_service.summarize_day = AsyncMock(side_effect=RuntimeError("boom"))
+        fix_summary = mocker.patch.object(cmd._daily, "fix_summary")
+
+        fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing summary"])
+
+        fix_summary.assert_not_called()
+        assert fixed == []
+
+    @mark.asyncio
+    async def test_fix_note_automatically__skips_summary_when_ai_returns_warning(
+        self, cmd: CommandManager, mocker: MockerFixture
+    ) -> None:
+        cmd.parser.parse.return_value = ParsedNote(summary=[])
+        cmd._daily.ai_service.summarize_day = AsyncMock(return_value="⚠️ No provider configured")
+        fix_summary = mocker.patch.object(cmd._daily, "fix_summary")
+
+        fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing summary"])
+
+        fix_summary.assert_not_called()
+        assert fixed == []
+
+    @mark.asyncio
+    async def test_fix_note_automatically__ignores_unfixable_missing_start_time(
+        self, cmd: CommandManager
+    ) -> None:
+        fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing start time"])
+
+        assert fixed == []
+
     # ── _note_issues / audit ─────────────────────────────────────────────────
 
     def test_note_issues__returns_empty_for_complete_note(
@@ -1232,6 +1330,9 @@ class TestCommands:
         assert stats["total"] == 3
 
     # ── sync_daily_notes ──────────────────────────────────────────────────────
+    # (unifies what used to be the separate `wk task sync` command: syncing
+    # today's notes against Jira/GitHub always covers any assigned task,
+    # regardless of status, plus code-review link revalidation.)
 
     @mark.asyncio
     async def test_sync_daily_notes__raises_when_file_missing(
@@ -1244,64 +1345,7 @@ class TestCommands:
             await cmd.sync_daily_notes(fixed_datetime)
 
     @mark.asyncio
-    async def test_sync_daily_notes__skips_write_when_all_tasks_present(
-        self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
-    ) -> None:
-        mocker.patch.object(cmd._daily, "_get_daily_notes_file_path", return_value="/day.md")
-        mocker.patch("taskjournal.commands.daily.exists", return_value=True)
-        existing = Task(id="1", description="Fix bug", status=Status.TODO)
-        cmd.parser.parse.return_value = ParsedNote(planned_tasks=[existing])
-        pending = Task(id="1", description="Fix bug", status=Status.TODO)
-        cmd.jira.get_current_sprint_tasks_all_assigned_to_me = AsyncMock(return_value=[pending])
-        cmd.jira.get_current_sprint_tasks_in_code_review = AsyncMock(return_value=[])
-        cmd.github.update_status_if_task_reviewed = AsyncMock()
-
-        await cmd.sync_daily_notes(fixed_datetime)
-
-        cmd.file_service.write_lines_to_file.assert_not_called()
-
-    @mark.asyncio
-    async def test_sync_daily_notes__corrects_status_of_task_moved_to_done(
-        self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
-    ) -> None:
-        # given: a task already tracked as in-progress in today's notes has
-        # since been moved to Done (or Rejected/any other status) in Jira.
-        mocker.patch.object(cmd._daily, "_get_daily_notes_file_path", return_value="/day.md")
-        mocker.patch("taskjournal.commands.daily.exists", return_value=True)
-        cmd.task_formatter.status_checkbox_char.side_effect = TaskFormatter.status_checkbox_char
-
-        lines = [
-            "## Planned Tasks\n",
-            " - [>] [JIRA-1]In progress task\n",
-        ]
-        cmd.file_service.get_lines.return_value = list(lines)
-        existing = Task(id="1", description="In progress task", status=Status.IN_PROGRESS)
-        cmd.parser.parse.return_value = ParsedNote(planned_tasks=[existing])
-
-        finished_task = Task(id="1", key="JIRA-1", description="In progress task", status=Status.DONE)
-        cmd.jira.get_current_sprint_tasks_all_assigned_to_me = AsyncMock(return_value=[finished_task])
-        cmd.jira.get_current_sprint_tasks_in_code_review = AsyncMock(return_value=[])
-        cmd.github.update_status_if_task_reviewed = AsyncMock()
-
-        await cmd.sync_daily_notes(fixed_datetime)
-
-        written_lines = cmd.file_service.write_lines_to_file.call_args[0][1]
-        assert any("JIRA-1" in line and "[x]" in line for line in written_lines)
-
-    # ── sync_tasks ────────────────────────────────────────────────────────────
-
-    @mark.asyncio
-    async def test_sync_tasks__raises_when_file_missing(
-        self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
-    ) -> None:
-        mocker.patch.object(cmd._daily, "_get_daily_notes_file_path", return_value="/missing.md")
-        mocker.patch("taskjournal.commands.daily.exists", return_value=False)
-
-        with raises(FileNotFoundError):
-            await cmd.sync_tasks(fixed_datetime)
-
-    @mark.asyncio
-    async def test_sync_tasks__adds_missing_and_corrects_stale_status(
+    async def test_sync_daily_notes__adds_missing_and_corrects_stale_status(
         self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
     ) -> None:
         mocker.patch.object(cmd._daily, "_get_daily_notes_file_path", return_value="/day.md")
@@ -1321,16 +1365,16 @@ class TestCommands:
         ]
         cmd.file_service.get_lines.return_value = list(lines)
 
-        # JIRA-1 is a new active task, not yet present anywhere in the notes
-        active_task = Task(id="1", key="JIRA-1", description="New active task", status=Status.IN_PROGRESS)
+        # JIRA-1 is a new assigned task, not yet present anywhere in the notes
+        assigned_task = Task(id="1", key="JIRA-1", description="New assigned task", status=Status.IN_PROGRESS)
         # JIRA-3 is already present in Code Review Tasks but was just approved (should flip to done)
         code_review_task = Task(id="3", key="JIRA-3", description="Review PR that got approved", status=Status.DONE)
 
-        cmd.jira.get_current_sprint_tasks_not_done_assigned_to_me = AsyncMock(return_value=[active_task])
+        cmd.jira.get_current_sprint_tasks_all_assigned_to_me = AsyncMock(return_value=[assigned_task])
         cmd.jira.get_current_sprint_tasks_in_code_review = AsyncMock(return_value=[code_review_task])
         cmd.github.update_status_if_task_reviewed = AsyncMock()
 
-        added, updated = await cmd.sync_tasks(fixed_datetime)
+        added, updated = await cmd.sync_daily_notes(fixed_datetime)
 
         assert added == 1
         assert updated == 1
@@ -1339,7 +1383,7 @@ class TestCommands:
         assert any("JIRA-3" in line and "[x]" in line for line in written_lines)
 
     @mark.asyncio
-    async def test_sync_tasks__corrects_merged_pr_no_longer_returned_by_jira(
+    async def test_sync_daily_notes__corrects_merged_pr_no_longer_returned_by_jira(
         self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
     ) -> None:
         # given: the Jira ticket already moved past "Code Review" (e.g. the
@@ -1356,12 +1400,12 @@ class TestCommands:
         ]
         cmd.file_service.get_lines.return_value = list(lines)
 
-        cmd.jira.get_current_sprint_tasks_not_done_assigned_to_me = AsyncMock(return_value=[])
+        cmd.jira.get_current_sprint_tasks_all_assigned_to_me = AsyncMock(return_value=[])
         cmd.jira.get_current_sprint_tasks_in_code_review = AsyncMock(return_value=[])
         cmd.github.update_status_if_task_reviewed = AsyncMock()
         cmd.github.has_user_approved_pr = AsyncMock(return_value=True)
 
-        added, updated = await cmd.sync_tasks(fixed_datetime)
+        added, updated = await cmd.sync_daily_notes(fixed_datetime)
 
         assert added == 0
         assert updated == 1
@@ -1372,7 +1416,7 @@ class TestCommands:
         assert any("BE-3171" in line and line.startswith(" - [x]") for line in written_lines)
 
     @mark.asyncio
-    async def test_sync_tasks__skips_write_when_everything_in_sync(
+    async def test_sync_daily_notes__skips_write_when_everything_in_sync(
         self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
     ) -> None:
         mocker.patch.object(cmd._daily, "_get_daily_notes_file_path", return_value="/day.md")
@@ -1383,12 +1427,12 @@ class TestCommands:
             "## Planned Tasks\n",
             " - [>] [JIRA-1]Already tracked\n",
         ]
-        active_task = Task(id="1", key="JIRA-1", description="Already tracked", status=Status.IN_PROGRESS)
-        cmd.jira.get_current_sprint_tasks_not_done_assigned_to_me = AsyncMock(return_value=[active_task])
+        assigned_task = Task(id="1", key="JIRA-1", description="Already tracked", status=Status.IN_PROGRESS)
+        cmd.jira.get_current_sprint_tasks_all_assigned_to_me = AsyncMock(return_value=[assigned_task])
         cmd.jira.get_current_sprint_tasks_in_code_review = AsyncMock(return_value=[])
         cmd.github.update_status_if_task_reviewed = AsyncMock()
 
-        added, updated = await cmd.sync_tasks(fixed_datetime)
+        added, updated = await cmd.sync_daily_notes(fixed_datetime)
 
         assert (added, updated) == (0, 0)
         cmd.file_service.write_lines_to_file.assert_not_called()

--- a/taskjournal/tests/services/backup_test.py
+++ b/taskjournal/tests/services/backup_test.py
@@ -1,6 +1,7 @@
-from datetime import datetime
 from pathlib import Path
 from zipfile import ZipFile
+
+from freezegun import freeze_time
 
 from taskjournal.services.backup import BackupService
 from taskjournal.services.base import ServiceStatus
@@ -56,14 +57,13 @@ class TestBackup:
 
         assert svc.health_check().status == ServiceStatus.OK
 
+    @freeze_time("2026-07-22 10:51:28")
     def test_create_backup_given_files_exist_when_backup_called_then_zip_created(
         self,
         backup_service_instance: BackupService,
     ) -> None:
         # given
-        expected_filename = (
-            f"DailyNotes_backup_{datetime.now().strftime('%Y_%m_%d')}.zip"
-        )
+        expected_filename = "DailyNotes_backup_2026_07_22_10_51_28.zip"
 
         # when
         backup_file = backup_service_instance.create()

--- a/taskjournal/tests/services/file_test.py
+++ b/taskjournal/tests/services/file_test.py
@@ -20,6 +20,14 @@ class TestFile:
         # then
         assert FileService.get_week_folder(base_dir, date) == expected_folder
 
+    def test_get_week_folder__uses_iso_year_at_year_boundary(
+        self, base_dir: str
+    ) -> None:
+        # 2025-12-29 is a Monday belonging to ISO week 1 of ISO-year 2026.
+        date = datetime(2025, 12, 29)
+        expected_folder = join(base_dir, "2026", "week1")
+        assert FileService.get_week_folder(base_dir, date) == expected_folder
+
     def test_write_to_file(self, mocker: MockerFixture) -> None:
         # given
         mock_file = mocker.mock_open()

--- a/taskjournal/tests/services/time_test.py
+++ b/taskjournal/tests/services/time_test.py
@@ -122,31 +122,47 @@ class TestTime:
         # then
         assert total == 3600
 
+    def test_get_expected_workday_seconds__mon_to_thu_is_8_5h(self) -> None:
+        for day in (datetime(2025, 1, 20), datetime(2025, 1, 21), datetime(2025, 1, 22), datetime(2025, 1, 23)):
+            assert TimeService.get_expected_workday_seconds(day) == int(8.5 * 3600)
+
+    def test_get_expected_workday_seconds__friday_is_6h(self) -> None:
+        friday = datetime(2025, 1, 24)
+        assert TimeService.get_expected_workday_seconds(friday) == 6 * 3600
+
+    def test_get_expected_week_seconds_before__monday_is_zero(self) -> None:
+        monday = datetime(2025, 1, 20, 9, 0, 0)
+        assert TimeService.get_expected_week_seconds_before(monday) == 0
+
+    def test_get_expected_week_seconds_before__friday_sums_four_8_5h_days(self) -> None:
+        friday = datetime(2025, 1, 24, 9, 0, 0)
+        assert TimeService.get_expected_week_seconds_before(friday) == int(4 * 8.5 * 3600)
+
     def test_estimated_finish_time__monday_no_accumulated(self) -> None:
-        # Monday, 0 days before → expected=0, extra=0, today=8h work + 1h lunch
+        # Monday, 0 days before → expected=0, extra=0, today=8.5h work + 1h lunch
         created = datetime(2025, 1, 20, 9, 0, 0)
-        result = TimeService.estimated_finish_time(created, accumulated_seconds=0, days_before_today=0)
-        assert result == created + timedelta(hours=9)
+        result = TimeService.estimated_finish_time(created, accumulated_seconds=0)
+        assert result == created + timedelta(hours=9, minutes=30)
 
     def test_estimated_finish_time__ahead_of_schedule(self) -> None:
-        # Friday, 4 days before → expected=32h, accumulated=36h, extra=+4h → today=4h + 1h lunch
+        # Friday, expected=4*8.5h=34h, accumulated=36h, extra=+2h → today=6h(cap)-2h=4h + 1h lunch
         created = datetime(2025, 1, 24, 9, 0, 0)
         accumulated = 36 * 3600
-        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated, days_before_today=4)
+        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated)
         assert result == created + timedelta(hours=5)
 
     def test_estimated_finish_time__behind_schedule(self) -> None:
-        # Friday, 4 days before → expected=32h, accumulated=28h, extra=-4h → today=8h (capped) + 1h lunch
+        # Friday, expected=34h, accumulated=28h, extra=-6h → today=6h (capped) + 1h lunch
         created = datetime(2025, 1, 24, 9, 0, 0)
         accumulated = 28 * 3600
-        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated, days_before_today=4)
-        assert result == created + timedelta(hours=9)
+        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated)
+        assert result == created + timedelta(hours=7)
 
     def test_estimated_finish_time__over_target_clamps_to_lunch(self) -> None:
         # So far ahead that today's work = 0, only 1h lunch remains
         created = datetime(2025, 1, 24, 9, 0, 0)
-        accumulated = 42 * 3600  # 10h extra over expected 32h
-        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated, days_before_today=4)
+        accumulated = 42 * 3600  # 8h extra over expected 34h
+        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated)
         assert result == created + timedelta(hours=1)
 
     def test_get_total_time_spent_deducts_lunch(self) -> None:


### PR DESCRIPTION
# TaskJournal Pull Request Template

## Overview

wk daily audit --fix — fix automàtic en lloc d'interactiu
- --fix ara arregla els documents incomplets automàticament, sense preguntar: summary generat amb IA, end time = hora d'inici + jornada esperada del dia, i time spent recalculat.
- Nou mètode DailyCommands.fix_note_automatically().

Bug fix: carpetes de setmana a cavall d'any
- FileService.get_week_folder usava l'any de calendari (date.year) en lloc de l'any ISO, cosa que enviava els dies 29–31 de desembre a la carpeta de l'any equivocat (p. ex. 2025/week1 en lloc de 2026/week1), duplicant folders "week1" de setmanes diferents i trencant wk holidays populate i l'audit de cobertura setmanal.
- Ara usa date.isocalendar() (any + setmana ISO), consistent amb el que ja assumia audit_weekly_coverage.

Unificació de sincronització: wk task sync → wk daily sync
- Eliminada la comanda wk task sync (redundant amb daily sync).
- wk daily sync ara inclou el millor de totes dues: consulta Jira amb qualsevol estat, afegeix tasques que falten a "Planned" i "Code Review", corregeix estats obsolets, i revalida PRs ja marcades com a aprovades.
- Nou flag opcional --prs per afegir també les PRs pendents de revisió (abans calia wk pr sync a part; ara és opt-in dins de daily sync, i wk pr sync es manté disponible independentment).

Model d'hores setmanals (8.5h Dl–Dj, 6h Dv)
- Substituït l'antic supòsit fix de 8h/dia per un model per dia de la setmana (40h/setmana: 8.5h de dilluns a dijous, 6h divendres), com a constants a constants.py.
- Nous helpers a TimeService: get_expected_workday_seconds() i get_expected_week_seconds_before().
- Aplicat a l'estimació d'hora de sortida (estimated_finish_time), al resum en crear el diari (create_daily_notes), a wk info (fila "Hours"), i al càlcul d'end-time automàtic de l'audit --fix.

Backup amb timestamp complet
- El nom del fitxer de backup ara inclou l'hora (DailyNotes_backup_YYYY_MM_DD_HH_MM_SS.zip) a més de la data, per evitar col·lisions si es generen diverses còpies el mateix dia.

Tests: 700 passen, mypy net (sense errors nous introduïts).

## Checklist:

Go through these points to ensure the PR fulfills expectations.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
