### PR TITLE
Small fixes 2

### DIFF
--- a/taskjournal/taskjournal/cli/commands/info.py
+++ b/taskjournal/taskjournal/cli/commands/info.py
@@ -164,7 +164,7 @@ def build_app() -> Typer:
         table.add_row("Dates", f"{monday.strftime('%d %b')} – {friday.strftime('%d %b %Y')}")
 
         accumulated_s = TimeService.get_accumulated_week_seconds(week_folder, today)
-        expected_s = TimeService.get_expected_week_seconds_before(today)
+        expected_s = TimeService.get_expected_week_seconds_before(week_folder, today)
         extra_s = accumulated_s - expected_s
         acc_h, acc_m = TimeService.seconds_to_hours_minutes(accumulated_s)
         exp_h, exp_m = TimeService.seconds_to_hours_minutes(expected_s)

--- a/taskjournal/taskjournal/commands/daily.py
+++ b/taskjournal/taskjournal/commands/daily.py
@@ -330,12 +330,15 @@ class DailyCommands:
         epic_names = TaskManager.get_unique_epic_names(all_tasks)
         tags_line = f"Tags: {', '.join(epic_names)}" if epic_names else ""
 
+        break_h, break_m = TimeService.seconds_to_hours_minutes(
+            TimeService.get_expected_break_seconds(create_datetime)
+        )
         daily_notes_content = Template(template_content).render(
             day_name=create_datetime.strftime("%A"),
             date=create_datetime.strftime("%Y-%m-%d"),
             start_time=create_datetime.strftime("%H:%M:%S"),
             end_time="",
-            break_time="01:00",
+            break_time=f"{break_h:02d}:{break_m:02d}",
             time_spent="",
             work_from=work_from,
             sprint_name=sprint_name,
@@ -354,11 +357,12 @@ class DailyCommands:
         week_folder = self._get_week_folder(create_datetime)
         accumulated_seconds = self.time_service.get_accumulated_week_seconds(week_folder, create_datetime)
         days_before_today = min(create_datetime.weekday(), 5)
-        expected_seconds = TimeService.get_expected_week_seconds_before(create_datetime)
+        expected_seconds = TimeService.get_expected_week_seconds_before(week_folder, create_datetime)
         extra_seconds = accumulated_seconds - expected_seconds
         today_seconds = TimeService.get_expected_workday_seconds(create_datetime)
         today_work_seconds = min(today_seconds, max(0, today_seconds - extra_seconds))
-        finish = self.time_service.estimated_finish_time(create_datetime, accumulated_seconds)
+        break_seconds = TimeService.get_expected_break_seconds(create_datetime)
+        finish = self.time_service.estimated_finish_time(create_datetime, week_folder, accumulated_seconds)
 
         accumulated_h, accumulated_m = TimeService.seconds_to_hours_minutes(accumulated_seconds)
         expected_h, expected_m = TimeService.seconds_to_hours_minutes(expected_seconds)
@@ -376,8 +380,9 @@ class DailyCommands:
         )
         streak = self.get_streak_stats(create_datetime)
         console.print(f"Streak: {streak['current']} day(s)  |  all-time best: {streak['longest']} day(s)")
+        break_label = f"{break_h}h {break_m:02d}m break" if break_seconds else "no break"
         console.print(
-            f"Today: {today_h}h {today_m:02d}m work + 1h lunch"
+            f"Today: {today_h}h {today_m:02d}m work + {break_label}"
             f"  →  estimated finish {finish.strftime('%H:%M')}"
         )
         if self._alarms_enabled:
@@ -742,7 +747,9 @@ class DailyCommands:
         if "missing end time" in issues:
             lines = self.file_service.get_lines(file_path)
             _, start_time = self.time_service.get_start_time(lines)
-            end_time = start_time + timedelta(seconds=TimeService.get_expected_workday_seconds(start_time))
+            expected_seconds = TimeService.get_expected_workday_seconds(start_time)
+            break_seconds = TimeService.get_expected_break_seconds(start_time)
+            end_time = start_time + timedelta(seconds=expected_seconds + break_seconds)
             self.fix_end_time_and_time_spent(file_path, end_time)
             fixed += ["end time", "time spent"]
         elif "missing time spent" in issues and self.fix_time_spent_from_file(file_path):

--- a/taskjournal/taskjournal/constants.py
+++ b/taskjournal/taskjournal/constants.py
@@ -12,6 +12,13 @@ WORK_OFFICE_DAYS = ["Tuesday", "Thursday"]
 WORKDAY_HOURS_MON_TO_THU = 8.5
 WORKDAY_HOURS_FRIDAY = 6.0
 
+# Break/lunch hours per weekday — no break on Friday since the workday is already short.
+WORKDAY_BREAK_HOURS_MON_TO_THU = 1.0
+WORKDAY_BREAK_HOURS_FRIDAY = 0.0
+
+# Work-hour equivalent credited for a vacation/holiday day (neutral in the weekly balance).
+WORKDAY_HOURS_IF_HOLIDAY = 8.0
+
 # Work locations
 WORK_LOCATION_HOME = "Home"
 WORK_LOCATION_OFFICE = "Office"

--- a/taskjournal/taskjournal/services/time.py
+++ b/taskjournal/taskjournal/services/time.py
@@ -1,9 +1,15 @@
 from datetime import date, datetime, timedelta
 from os import makedirs
-from os.path import exists, join
+from os.path import dirname, exists, join
 
 from taskjournal.config import BASE_DIR, TEMPLATE_FORMAT
-from taskjournal.constants import WORKDAY_HOURS_FRIDAY, WORKDAY_HOURS_MON_TO_THU
+from taskjournal.constants import (
+    WORKDAY_BREAK_HOURS_FRIDAY,
+    WORKDAY_BREAK_HOURS_MON_TO_THU,
+    WORKDAY_HOURS_FRIDAY,
+    WORKDAY_HOURS_IF_HOLIDAY,
+    WORKDAY_HOURS_MON_TO_THU,
+)
 from taskjournal.services.base import BaseService
 from taskjournal.services.file import FileService
 from taskjournal.services.logger import logger
@@ -23,7 +29,9 @@ class TimeService(BaseService):
             lines = FileService.get_lines(daily_notes_file)
             _, created_time = TimeService.get_start_time(lines)
             elapsed_hours = (datetime.now() - created_time).total_seconds() / 3600
-            finish_time = created_time + timedelta(hours=9)
+            week_folder = dirname(daily_notes_file)
+            accumulated_seconds = TimeService.get_accumulated_week_seconds(week_folder, created_time)
+            finish_time = TimeService.estimated_finish_time(created_time, week_folder, accumulated_seconds)
             return created_time, elapsed_hours, finish_time
         except Exception as e:
             logger.error(f"Error calculating working hours: {e}")
@@ -58,11 +66,26 @@ class TimeService(BaseService):
         return total_time
 
     @staticmethod
+    def get_holiday_notes_name(date: datetime | date) -> str:
+        return date.strftime("%Y-%m-%d") + f"-DailyNotes-Holidays.{TEMPLATE_FORMAT}"
+
+    @staticmethod
+    def is_holiday_note(week_folder: str, day: datetime | date) -> bool:
+        return exists(join(week_folder, TimeService.get_holiday_notes_name(day)))
+
+    @staticmethod
+    def get_holiday_equivalent_seconds() -> int:
+        return int(WORKDAY_HOURS_IF_HOLIDAY * 3600)
+
+    @staticmethod
     def get_accumulated_week_seconds(week_folder: str, today: datetime) -> int:
         start_of_week = today - timedelta(days=today.weekday())
         total = 0
         for i in range(min(today.weekday(), 5)):  # Mon up to (not including) today, max Fri
             day = start_of_week + timedelta(days=i)
+            if TimeService.is_holiday_note(week_folder, day):
+                total += TimeService.get_holiday_equivalent_seconds()
+                continue
             daily_file = join(week_folder, TimeService.get_daily_notes_name(day))
             if exists(daily_file):
                 try:
@@ -77,25 +100,35 @@ class TimeService(BaseService):
         return int(hours * 3600)
 
     @staticmethod
-    def get_expected_week_seconds_before(today: datetime) -> int:
+    def get_expected_break_seconds(day: datetime | date) -> int:
+        hours = WORKDAY_BREAK_HOURS_FRIDAY if day.weekday() == 4 else WORKDAY_BREAK_HOURS_MON_TO_THU
+        return int(hours * 3600)
+
+    @staticmethod
+    def get_expected_week_seconds_before(week_folder: str, today: datetime) -> int:
         start_of_week = today - timedelta(days=today.weekday())
         days_before_today = min(today.weekday(), 5)  # Mon..Fri, capped for weekend notes
-        return sum(
-            TimeService.get_expected_workday_seconds(start_of_week + timedelta(days=i))
-            for i in range(days_before_today)
-        )
+        total = 0
+        for i in range(days_before_today):
+            day = start_of_week + timedelta(days=i)
+            if TimeService.is_holiday_note(week_folder, day):
+                total += TimeService.get_holiday_equivalent_seconds()
+            else:
+                total += TimeService.get_expected_workday_seconds(day)
+        return total
 
     @staticmethod
     def estimated_finish_time(
         created_time: datetime,
+        week_folder: str,
         accumulated_seconds: int = 0,
     ) -> datetime:
-        expected_seconds = TimeService.get_expected_week_seconds_before(created_time)
+        expected_seconds = TimeService.get_expected_week_seconds_before(week_folder, created_time)
         extra_seconds = accumulated_seconds - expected_seconds
         today_seconds = TimeService.get_expected_workday_seconds(created_time)
         today_work_seconds = min(today_seconds, max(0, today_seconds - extra_seconds))
-        lunch_seconds = 3600
-        return created_time + timedelta(seconds=today_work_seconds + lunch_seconds)
+        break_seconds = TimeService.get_expected_break_seconds(created_time)
+        return created_time + timedelta(seconds=today_work_seconds + break_seconds)
 
     @staticmethod
     def get_start_time(lines: list[str]) -> tuple[int, datetime]:

--- a/taskjournal/tests/commands/commands_test.py
+++ b/taskjournal/tests/commands/commands_test.py
@@ -901,20 +901,21 @@ class TestCommands:
     async def test_fix_note_automatically__fixes_missing_end_time_as_start_plus_expected_hours(
         self, cmd: CommandManager, mocker: MockerFixture, fixed_datetime: datetime
     ) -> None:
-        # fixed_datetime (2025-01-15) is a Wednesday → 8.5h expected workday
+        # fixed_datetime (2025-01-15) is a Wednesday → 8.5h work + 1h break
         cmd.file_service.get_lines.return_value = ["**Start Time:** 09:00:00\n"]
         cmd.time_service.get_start_time.return_value = (0, fixed_datetime.replace(hour=9, minute=0))
         fix_end = mocker.patch.object(cmd._daily, "fix_end_time_and_time_spent")
 
         fixed = await cmd.fix_note_automatically("2026-01-05", "/day.md", ["missing end time"])
 
-        fix_end.assert_called_once_with("/day.md", fixed_datetime.replace(hour=17, minute=30))
+        fix_end.assert_called_once_with("/day.md", fixed_datetime.replace(hour=18, minute=30))
         assert fixed == ["end time", "time spent"]
 
     @mark.asyncio
     async def test_fix_note_automatically__fixes_missing_end_time_as_start_plus_6h_on_friday(
         self, cmd: CommandManager, mocker: MockerFixture
     ) -> None:
+        # Friday → 6h work + 0h break
         friday = datetime(2025, 1, 17, 9, 0, 0)
         cmd.file_service.get_lines.return_value = ["**Start Time:** 09:00:00\n"]
         cmd.time_service.get_start_time.return_value = (0, friday)

--- a/taskjournal/tests/services/time_test.py
+++ b/taskjournal/tests/services/time_test.py
@@ -9,16 +9,17 @@ from taskjournal.services.time import TimeService
 
 class TestTime:
 
-    @freeze_time("2025-01-19 12:00:00")
+    @freeze_time("2025-01-20 12:00:00")
     def test_calculate_working_hours_valid(self, mocker: MockerFixture) -> None:
-        # given
-        created_time = "2025-01-19 09:00:00"
+        # given — Monday, no prior days accumulated this week
+        created_time = "2025-01-20 09:00:00"
         mock_open = mocker.mock_open(read_data=f"Start time: {created_time}\n")
         mocker.patch("builtins.open", mock_open)
         mocker.patch(
             "taskjournal.services.time.TimeService.get_start_time",
             return_value=(0, datetime.strptime(created_time, "%Y-%m-%d %H:%M:%S")),
         )
+        mocker.patch("taskjournal.services.time.exists", return_value=False)
 
         # when
         created, elapsed, finish = TimeService.calculate_working_hours("notes.txt")
@@ -26,7 +27,7 @@ class TestTime:
         # then
         assert created == datetime.strptime(created_time, "%Y-%m-%d %H:%M:%S")
         assert round(elapsed, 1) == 3.0
-        assert finish == created + timedelta(hours=9)
+        assert finish == created + timedelta(hours=9, minutes=30)
 
     def test_calculate_working_hours_no_start_line(self, mocker: MockerFixture) -> None:
         # given
@@ -130,39 +131,69 @@ class TestTime:
         friday = datetime(2025, 1, 24)
         assert TimeService.get_expected_workday_seconds(friday) == 6 * 3600
 
-    def test_get_expected_week_seconds_before__monday_is_zero(self) -> None:
+    def test_get_expected_week_seconds_before__monday_is_zero(self, mocker: MockerFixture) -> None:
+        mocker.patch("taskjournal.services.time.exists", return_value=False)
         monday = datetime(2025, 1, 20, 9, 0, 0)
-        assert TimeService.get_expected_week_seconds_before(monday) == 0
+        assert TimeService.get_expected_week_seconds_before("/tmp/base/2025/week3", monday) == 0
 
-    def test_get_expected_week_seconds_before__friday_sums_four_8_5h_days(self) -> None:
+    def test_get_expected_week_seconds_before__friday_sums_four_8_5h_days(self, mocker: MockerFixture) -> None:
+        mocker.patch("taskjournal.services.time.exists", return_value=False)
         friday = datetime(2025, 1, 24, 9, 0, 0)
-        assert TimeService.get_expected_week_seconds_before(friday) == int(4 * 8.5 * 3600)
+        assert TimeService.get_expected_week_seconds_before("/tmp/base/2025/week3", friday) == int(4 * 8.5 * 3600)
 
-    def test_estimated_finish_time__monday_no_accumulated(self) -> None:
-        # Monday, 0 days before → expected=0, extra=0, today=8.5h work + 1h lunch
+    def test_get_expected_week_seconds_before__holiday_day_counts_as_neutral_8h(
+        self, mocker: MockerFixture
+    ) -> None:
+        # Monday is a holiday (marker file exists) → counted as 8h instead of 8.5h
+        mocker.patch(
+            "taskjournal.services.time.exists",
+            side_effect=lambda path: "Holidays" in path,
+        )
+        tuesday = datetime(2025, 1, 21, 9, 0, 0)
+        result = TimeService.get_expected_week_seconds_before("/tmp/base/2025/week3", tuesday)
+        assert result == 8 * 3600
+
+    def test_estimated_finish_time__monday_no_accumulated(self, mocker: MockerFixture) -> None:
+        # Monday, 0 days before → expected=0, extra=0, today=8.5h work + 1h break
+        mocker.patch("taskjournal.services.time.exists", return_value=False)
         created = datetime(2025, 1, 20, 9, 0, 0)
-        result = TimeService.estimated_finish_time(created, accumulated_seconds=0)
+        result = TimeService.estimated_finish_time(created, "/tmp/base/2025/week3", accumulated_seconds=0)
         assert result == created + timedelta(hours=9, minutes=30)
 
-    def test_estimated_finish_time__ahead_of_schedule(self) -> None:
-        # Friday, expected=4*8.5h=34h, accumulated=36h, extra=+2h → today=6h(cap)-2h=4h + 1h lunch
+    def test_estimated_finish_time__ahead_of_schedule(self, mocker: MockerFixture) -> None:
+        # Friday, expected=4*8.5h=34h, accumulated=36h, extra=+2h → today=6h(cap)-2h=4h + 0h break
+        mocker.patch("taskjournal.services.time.exists", return_value=False)
         created = datetime(2025, 1, 24, 9, 0, 0)
         accumulated = 36 * 3600
-        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated)
-        assert result == created + timedelta(hours=5)
+        result = TimeService.estimated_finish_time(created, "/tmp/base/2025/week3", accumulated_seconds=accumulated)
+        assert result == created + timedelta(hours=4)
 
-    def test_estimated_finish_time__behind_schedule(self) -> None:
-        # Friday, expected=34h, accumulated=28h, extra=-6h → today=6h (capped) + 1h lunch
+    def test_estimated_finish_time__behind_schedule(self, mocker: MockerFixture) -> None:
+        # Friday, expected=34h, accumulated=28h, extra=-6h → today=6h (capped) + 0h break
+        mocker.patch("taskjournal.services.time.exists", return_value=False)
         created = datetime(2025, 1, 24, 9, 0, 0)
         accumulated = 28 * 3600
-        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated)
-        assert result == created + timedelta(hours=7)
+        result = TimeService.estimated_finish_time(created, "/tmp/base/2025/week3", accumulated_seconds=accumulated)
+        assert result == created + timedelta(hours=6)
 
-    def test_estimated_finish_time__over_target_clamps_to_lunch(self) -> None:
-        # So far ahead that today's work = 0, only 1h lunch remains
+    def test_estimated_finish_time__friday_over_target_finishes_immediately(
+        self, mocker: MockerFixture
+    ) -> None:
+        # So far ahead that today's work = 0, and Friday has no break to clamp to
+        mocker.patch("taskjournal.services.time.exists", return_value=False)
         created = datetime(2025, 1, 24, 9, 0, 0)
         accumulated = 42 * 3600  # 8h extra over expected 34h
-        result = TimeService.estimated_finish_time(created, accumulated_seconds=accumulated)
+        result = TimeService.estimated_finish_time(created, "/tmp/base/2025/week3", accumulated_seconds=accumulated)
+        assert result == created
+
+    def test_estimated_finish_time__monday_over_target_clamps_to_break(
+        self, mocker: MockerFixture
+    ) -> None:
+        # Monday-Thursday still keep the 1h break as a floor even when far ahead of schedule
+        mocker.patch("taskjournal.services.time.exists", return_value=False)
+        created = datetime(2025, 1, 21, 9, 0, 0)  # Tuesday
+        accumulated = 20 * 3600  # way more than the 8.5h expected before Tuesday
+        result = TimeService.estimated_finish_time(created, "/tmp/base/2025/week3", accumulated_seconds=accumulated)
         assert result == created + timedelta(hours=1)
 
     def test_get_total_time_spent_deducts_lunch(self) -> None:
@@ -272,7 +303,10 @@ class TestTime:
             return_value="/tmp/base/2025/week3",
         )
         mocker.patch("taskjournal.services.time.makedirs")
-        mocker.patch("taskjournal.services.time.exists", return_value=True)
+        mocker.patch(
+            "taskjournal.services.time.exists",
+            side_effect=lambda path: "Holidays" not in path,
+        )
         mocker.patch(
             "taskjournal.services.time.TimeService.get_total_time_from_daily_notes",
             return_value=3600,
@@ -280,6 +314,25 @@ class TestTime:
         today = datetime(2025, 1, 22)  # Wednesday — 2 days before (Mon, Tue)
         result = TimeService.get_accumulated_week_seconds("/tmp/base/2025/week3", today)
         assert result == 7200  # 2 x 3600
+
+    def test_get_accumulated_week_seconds_holiday_day_counts_as_neutral_8h(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("taskjournal.services.time.TEMPLATE_FORMAT", "md")
+        mocker.patch("taskjournal.services.time.BASE_DIR", "/tmp/base")
+        mocker.patch(
+            "taskjournal.services.time.FileService.get_week_folder",
+            return_value="/tmp/base/2025/week3",
+        )
+        mocker.patch("taskjournal.services.time.makedirs")
+        # Monday is a holiday (marker file exists); Tuesday has no notes at all.
+        mocker.patch(
+            "taskjournal.services.time.exists",
+            side_effect=lambda path: "Holidays" in path and "2025-01-20" in path,
+        )
+        wednesday = datetime(2025, 1, 22)
+        result = TimeService.get_accumulated_week_seconds("/tmp/base/2025/week3", wednesday)
+        assert result == 8 * 3600
 
     def test_get_accumulated_week_seconds_skips_missing_files(
         self, mocker: MockerFixture
@@ -306,7 +359,10 @@ class TestTime:
             return_value="/tmp/base/2025/week3",
         )
         mocker.patch("taskjournal.services.time.makedirs")
-        mocker.patch("taskjournal.services.time.exists", return_value=True)
+        mocker.patch(
+            "taskjournal.services.time.exists",
+            side_effect=lambda path: "Holidays" not in path,
+        )
         mocker.patch(
             "taskjournal.services.time.TimeService.get_total_time_from_daily_notes",
             side_effect=ValueError("bad file"),


### PR DESCRIPTION
# TaskJournal Pull Request Template

## Overview

1. Trencament de pausa dinàmica per dia de la setmana — s'afegeixen WORKDAY_BREAK_HOURS_MON_TO_THU (1h) i WORKDAY_BREAK_HOURS_FRIDAY (0h) a constants.py, i el nou mètode TimeService.get_expected_break_seconds() que substitueix l'1h de pausa hardcodejada per un valor que depèn del dia (divendres no té pausa).
2. Suport per a dies de vacances/festius com a neutrals — nous mètodes is_holiday_note(), get_holiday_notes_name() i get_holiday_equivalent_seconds() a TimeService: si existeix un fitxer *-DailyNotes-Holidays.md per a un dia, aquest compta com a 8h neutres (WORKDAY_HOURS_IF_HOLIDAY) tant a get_accumulated_week_seconds() com a get_expected_week_seconds_before(), en lloc d'ignorar-lo o penalitzar-lo.
3. get_expected_week_seconds_before() i estimated_finish_time() ara reben week_folder — necessari perquè puguin consultar si un dia és festiu; s'actualitzen totes les crides a info.py, daily.py i time.py (inclòs calculate_working_hours, que abans feia servir un timedelta(hours=9) fix i ara reutilitza estimated_finish_time).
4. DailyCommands — el break_time de la plantilla diària i el missatge "Today: Xh Ym work + ... break" es calculen ara dinàmicament amb get_expected_break_seconds() en lloc del text fix "01:00" / "1h lunch"; també fix_note_automatically (hora de fi per notes amb "missing end time") suma correctament work + break esperats en lloc d'assumir sempre 1h.
5. Fix a info.py — la crida a get_expected_week_seconds_before no passava week_folder, cosa que hauria trencat amb la nova signatura.
6. Tests actualitzats/ampliats (time_test.py, commands_test.py) — s'adapten totes les crides a la nova signatura, i s'afegeixen casos nous: dia festiu comptant com a 8h neutres, pausa 0h el divendres (finish immediat quan es va molt avançat), i pausa d'1h com a mínim entre setmana.

## Checklist:

Go through these points to ensure the PR fulfills expectations.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
